### PR TITLE
Add clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+IndentWidth: 4
+DerivePointerAlignment: false
+PointerAlignment: Left
+---

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "[cpp]": {
+        "editor.defaultFormatter": "ms-vscode.cpptools"
+    },
+    "editor.formatOnSave": true
+}

--- a/sample/src/add_sample.cpp
+++ b/sample/src/add_sample.cpp
@@ -1,7 +1,6 @@
 #include "add_sample.hpp"
 
-int add_sample(int val_a, int val_b)
-{
+int add_sample(int val_a, int val_b) {
     int res;
     res = val_a + val_b;
     return res;

--- a/sample/src/add_sample.hpp
+++ b/sample/src/add_sample.hpp
@@ -3,4 +3,4 @@
 
 int add_sample(int val_a, int val_b);
 
-#endif //ADD_SAMPLE_HPP
+#endif  // ADD_SAMPLE_HPP

--- a/sample/src/print_sample.cpp
+++ b/sample/src/print_sample.cpp
@@ -1,7 +1,5 @@
-#include <iostream>
 #include "print_sample.hpp"
 
-void print_sample()
-{
-    std::cout << "This is a sample program." << std::endl;
-}
+#include <iostream>
+
+void print_sample() { std::cout << "This is a sample program." << std::endl; }

--- a/sample/src/print_sample.hpp
+++ b/sample/src/print_sample.hpp
@@ -3,4 +3,4 @@
 
 void print_sample();
 
-#endif //PRINT_SAMPLE_HPP
+#endif  // PRINT_SAMPLE_HPP

--- a/sample/test/main.cpp
+++ b/sample/test/main.cpp
@@ -1,9 +1,9 @@
-#include "print_sample.hpp"
-#include "add_sample.hpp"
 #include <iostream>
 
-int main()
-{
+#include "add_sample.hpp"
+#include "print_sample.hpp"
+
+int main() {
     int val_a = 1;
     int val_b = 5;
     int add_res;


### PR DESCRIPTION
## Overview
Enable clang-format.
Source codes are automatically formatted on save according to  the settings in .clang-format.

## Changes
- .clang-format and settings.json will be added
- sample codes will be formatted

## Test
N/A